### PR TITLE
Moved locking code into a component

### DIFF
--- a/src/main/Body.tsx
+++ b/src/main/Body.tsx
@@ -10,6 +10,7 @@ import { useSelector } from 'react-redux';
 import { selectIsEnd } from '../redux/endSlice'
 import { selectIsError } from "../redux/errorSlice";
 import { settings } from '../config';
+import Lock from "./Lock";
 
 
 const Body: React.FC<{}> = () => {
@@ -37,6 +38,7 @@ const Body: React.FC<{}> = () => {
         <div css={bodyStyle}>
           <MainMenu />
           <MainContent />
+          <Lock />
         </div>
       );
     }

--- a/src/main/Lock.tsx
+++ b/src/main/Lock.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { settings } from "../config";
+import { setLock, video } from "../redux/videoSlice";
+import { client } from "../util/client";
+import { useInterval } from "../util/utilityFunctions";
+
+
+const Lock: React.FC<{}> = () => {
+
+  const dispatch = useDispatch();
+
+  const lockingActive = useSelector((state: { videoState: { lockingActive: video["lockingActive"] } }) => state.videoState.lockingActive);
+  const lockRefresh = useSelector((state: { videoState: { lockRefresh: video["lockRefresh"] } }) => state.videoState.lockRefresh);
+  const lock = useSelector((state: { videoState: { lock: video["lock"] } }) => state.videoState.lock);
+
+  let endpoint = `${settings.opencast.url}/editor/${settings.id}/editorLock`
+  let body = lock
+  let delay = lockRefresh
+
+  // Tell Opencast if we want to lock
+  useEffect(() => {
+    if (lockingActive) {
+      client.lock(endpoint, body);
+      body.lockRefresh = true;
+      dispatch(setLock(body))
+    }
+    // put client.release code here?
+
+  // Only run this when the locking state changes
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lockingActive])
+
+  // Refresh locking state?
+  useInterval( async () => {
+    await client.refresh(endpoint, body)
+  }, delay);
+
+  return (<></>);
+}
+
+export default Lock;

--- a/src/util/client.js
+++ b/src/util/client.js
@@ -75,11 +75,3 @@ client.get = function (endpoint, customConfig = {}) {
 client.post = function (endpoint, body, customConfig = {}) {
   return client(endpoint, 'POST', {body, ...customConfig})
 }
-
-client.startLock = function (endpoint, body, delay, customConfig = {}) {
-  client.lock(endpoint, body, customConfig);
-  body.lockRefresh = true;
-  useInterval( async () => {
-    const refreshLock = await client.refresh(endpoint,body, customConfig)
-  }, delay);
-}

--- a/src/util/utilityFunctions.ts
+++ b/src/util/utilityFunctions.ts
@@ -73,21 +73,27 @@ export function checkFlexGapSupport() {
 	return flexGapIsSupported
 }
 
-export function useInterval(callback, delay:number) {
-  const savedCallback = useRef();
+// Runs a callback every delay milliseconds (I think)
+// Pass delay = null to stop
+// Based off: https://overreacted.io/making-setinterval-declarative-with-react-hooks/
+type IntervalFunction = () => ( unknown | void )
+export function useInterval(callback: IntervalFunction, delay: number | null) {
+
+  const savedCallback = useRef<IntervalFunction | null>( null )
+
   useEffect(() => {
-    savedCallback.current = callback;
-  }, [callback]);
-  
+    savedCallback.current = callback
+  })
+
   useEffect(() => {
     function tick() {
-      savedCallback.current();
+      if ( savedCallback.current !== null ) {
+        savedCallback.current()
+      }
     }
     if (delay !== null) {
-      const id = setInterval(tick, delay);
-      return () => {
-        clearInterval(id);
-      };
+      const id = setInterval(tick, delay)
+      return () => { clearInterval(id) }
     }
   }, [callback, delay]);
 }


### PR DESCRIPTION
Stateful information like intervals needs to live in the React DOM somewhere, so I've put the call in an otherwise empty React component called `Lock` (not a nice solution, as you generally want to avoid components that don't do any actual displaying, but I don't know any better way currently). I also made `Lock` responsible for sending post requests to Opencast about locking when necessary. And fixed some typing issues.

I haven't really tested this beyond "it compiles" and "it doesn't immediately crash the app", so please test if this actually does what you want.